### PR TITLE
feat(aggregates+ui): add 11_build_features_by_stop_line and Streamlit…

### DIFF
--- a/app/streamlit_by_stop_line.py
+++ b/app/streamlit_by_stop_line.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# app/streamlit_by_stop_line.py
+"""
+Streamlit Dashboard — Aggregated features by Stop × Line (10-min bins)
+
+Overview
+--------
+This app visualizes the aggregated table produced by the ETL step
+`11_build_features_by_stop_line.py`. Each row represents metrics for a specific
+(line_text, stop_code) and a 10-minute time bin (`sched_bin`).
+
+What you can do here
+--------------------
+- Filter by line(s), stop(s), and date range
+- Pick a metric to visualize as a time series (e.g., avg delay, share of late trips)
+- Inspect an hour × day heatmap of average delays
+- Download the filtered slice as CSV
+
+Inputs
+------
+- Either a Parquet file at: data/gold/features_by_stop_line.parquet
+- Or a DuckDB warehouse containing table: features_by_stop_line
+
+Expected columns (from the ETL)
+-------------------------------
+- Keys: line_text, stop_code, stop_name, stop_key, sched_bin (UTC timestamp)
+- Traffic: n_trips, delay_avg_min, delay_p50_min, delay_p90_min, share_late_ge2
+- Weather (aggregated): temp_c_mean, rain_mm_mean, rain_mm_max, wind_ms_mean, gust_ms_mean,
+                        humidity_mean, pressure_hpa_mean, global_rad_wm2_mean, sunshine_min_mean, dewpoint_c_mean
+- Coalesce flag (aggregated): share_coalesce (optional in UI, useful for QA)
+
+Notes
+-----
+- All timestamps are treated as UTC and displayed as-is.
+- `share_late_ge2` and `share_coalesce` are fractions in [0,1]; KPIs display them as percentages.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, List
+
+import duckdb
+import pandas as pd
+import streamlit as st
+import altair as alt
+
+# =============================================================================
+# Page configuration
+# =============================================================================
+st.set_page_config(page_title="TPG · Features by Stop × Line", layout="wide")
+st.title("📈 TPG · Features by Stop × Line (10-min bin)")
+st.caption("Aggregated metrics per (line × stop × 10-minute slot).")
+
+# =============================================================================
+# Helpers
+# =============================================================================
+@st.cache_resource
+def get_con(db_path: Optional[str]) -> duckdb.DuckDBPyConnection:
+    """
+    Create a read-only DuckDB connection.
+    Cached across reruns to avoid opening multiple connections.
+    """
+    return duckdb.connect(db_path or "data/warehouse.duckdb", read_only=True)
+
+def load_table_or_parquet(con: duckdb.DuckDBPyConnection, parquet_path: Optional[str] = None) -> pd.DataFrame:
+    """
+    Load the aggregated dataset from a Parquet file if provided and exists,
+    otherwise from the DuckDB table `features_by_stop_line`.
+
+    The function fails fast with a Streamlit error if neither source is available.
+    """
+    if parquet_path and os.path.exists(parquet_path):
+        df = pd.read_parquet(parquet_path)
+        return df
+
+    exists = con.execute("""
+      SELECT COUNT(*) FROM information_schema.tables
+      WHERE table_name = 'features_by_stop_line'
+    """).fetchone()[0]
+    if not exists:
+        st.error("Table 'features_by_stop_line' not found and no Parquet provided.")
+        st.stop()
+
+    return con.execute("SELECT * FROM features_by_stop_line").df()
+
+def enhance_time(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Add helper time columns derived from `sched_bin`:
+      - date  (YYYY-MM-DD)
+      - hour  (0..23)
+      - dow   (0=Mon .. 6=Sun)
+
+    Assumes `sched_bin` is a UTC timestamp string/ts; coerces to pandas datetime[UTC].
+    """
+    out = df.copy()
+    out["sched_bin"] = pd.to_datetime(out["sched_bin"], utc=True, errors="coerce")
+    out["date"] = out["sched_bin"].dt.date
+    out["hour"] = out["sched_bin"].dt.hour
+    out["dow"]  = out["sched_bin"].dt.dayofweek
+    return out
+
+def metric_human_name(key: str) -> str:
+    """
+    Human-friendly labels for y-axis / selectors.
+    Extend this mapping as you add new aggregated columns.
+    """
+    labels = {
+        "delay_avg_min":      "Average delay (min)",
+        "delay_p50_min":      "Median delay (min)",
+        "delay_p90_min":      "P90 delay (min)",
+        "share_late_ge2":     "Share delays ≥2min",
+        "rain_mm_mean":       "Rain mean (mm/10min)",
+        "rain_mm_max":        "Rain max (mm/10min)",
+        "wind_ms_mean":       "Wind mean (m/s)",
+        "gust_ms_mean":       "Gust mean (m/s)",
+        "temp_c_mean":        "Temperature mean (°C)",
+        "humidity_mean":      "Humidity mean (%)",
+        "pressure_hpa_mean":  "Pressure mean (hPa)",
+        "global_rad_wm2_mean":"Global radiation (W/m²)",
+        "sunshine_min_mean":  "Sunshine mean (min/10min)",
+        "dewpoint_c_mean":    "Dew point mean (°C)",
+        # Optional QA metric:
+        "share_coalesce":     "Share coalesced (arrival→depart)",
+    }
+    return labels.get(key, key)
+
+def safe_pct(v: float) -> str:
+    """Format a fraction in [0,1] as a percentage string with one decimal place."""
+    try:
+        return f"{100.0 * float(v):.1f}%"
+    except Exception:
+        return "—"
+
+# =============================================================================
+# Sidebar — data sources
+# =============================================================================
+with st.sidebar:
+    st.header("Data")
+    db_path = st.text_input("DuckDB path", value="data/warehouse.duckdb")
+    parquet_path = st.text_input("Or Parquet (optional)", value="data/gold/features_by_stop_line.parquet")
+    parquet_path = parquet_path or None
+
+con = get_con(db_path)
+df = load_table_or_parquet(con, parquet_path)
+if df.empty:
+    st.info("No data to display.")
+    st.stop()
+
+df = enhance_time(df)
+
+# =============================================================================
+# Sidebar — filters & metric selection
+# =============================================================================
+with st.sidebar:
+    st.header("Filters")
+
+    # 1) Line filter (multiselect)
+    lines: List[str] = sorted(df["line_text"].dropna().astype(str).unique().tolist())
+    line_sel = st.multiselect("Line(s)", lines, default=lines[:1] if lines else [])
+
+    # 2) Stop filter (dependent on selected lines)
+    #    We use stop_key as the actual selection key and render stop_name as label.
+    stop_map = (
+        df.loc[df["line_text"].isin(line_sel), ["stop_key", "stop_name"]]
+          .dropna().drop_duplicates().sort_values("stop_name")
+    )
+    options = stop_map["stop_key"].tolist()
+    labels  = stop_map["stop_name"].tolist()
+    name_for = dict(zip(options, labels))
+
+    stop_sel = st.multiselect(
+        "Stop(s)",
+        options=options,
+        default=options[:1] if options else [],
+        format_func=lambda x: name_for.get(x, str(x)),
+        help="Use the search box to find a stop by name."
+    )
+
+    # 3) Date range (inclusive) derived from available data
+    date_min, date_max = df["date"].min(), df["date"].max()
+    dr = st.date_input(
+        "Date range",
+        value=(date_min, date_max),
+        min_value=date_min, max_value=date_max
+    )
+
+    # 4) Metric to plot (time series)
+    metric_choices = [
+        "delay_avg_min", "delay_p50_min", "delay_p90_min",
+        "share_late_ge2",
+        "rain_mm_mean", "rain_mm_max",
+        "wind_ms_mean", "gust_ms_mean",
+        "temp_c_mean", "humidity_mean",
+        "global_rad_wm2_mean", "sunshine_min_mean", "dewpoint_c_mean",
+        # Uncomment if you want to expose the QA metric in the UI:
+        "share_coalesce",
+    ]
+    y_metric = st.selectbox("Metric", metric_choices, index=0, format_func=metric_human_name)
+
+# =============================================================================
+# Apply filters
+# =============================================================================
+mask = pd.Series(True, index=df.index)
+if line_sel:
+    mask &= df["line_text"].isin(line_sel)
+if stop_sel:
+    mask &= df["stop_key"].isin(stop_sel)
+if isinstance(dr, (list, tuple)) and len(dr) == 2:
+    d0, d1 = pd.to_datetime(dr[0]), pd.to_datetime(dr[1])
+    mask &= (pd.to_datetime(df["date"]) >= d0) & (pd.to_datetime(df["date"]) <= d1)
+
+view = df.loc[mask].sort_values("sched_bin").copy()
+st.caption(f"{len(view):,} rows after filters")
+
+# =============================================================================
+# KPIs
+# =============================================================================
+colA, colB, colC, colD = st.columns(4)
+with colA:
+    trips = int(view["n_trips"].sum()) if "n_trips" in view else 0
+    st.metric("Trips", f"{trips:,}")
+with colB:
+    st.metric("Avg delay (min)",
+              f"{view['delay_avg_min'].mean():.2f}" if "delay_avg_min" in view and not view.empty else "—")
+with colC:
+    st.metric("P90 delay (min)",
+              f"{view['delay_p90_min'].mean():.2f}" if "delay_p90_min" in view and not view.empty else "—")
+with colD:
+    st.metric("Share ≥2min",
+              safe_pct(view["share_late_ge2"].mean()) if "share_late_ge2" in view and not view.empty else "—")
+
+st.divider()
+
+# =============================================================================
+# Time series — metric over time (grouped by stop)
+# =============================================================================
+st.subheader(f"Time series — {metric_human_name(y_metric)}")
+if not view.empty and y_metric in view.columns:
+    # Build a line chart over time, one line per stop_key (legend uses stop_name if unique).
+    # Altair handles interactive hover tooltips nicely.
+    label_col = "stop_name" if "stop_name" in view.columns else "stop_key"
+    timeseries = (
+        alt.Chart(view)
+        .mark_line(point=False)
+        .encode(
+            x=alt.X("sched_bin:T", title="Time (UTC)"),
+            y=alt.Y(f"{y_metric}:Q", title=metric_human_name(y_metric)),
+            color=alt.Color(f"{label_col}:N", title="Stop"),
+            tooltip=[
+                alt.Tooltip("sched_bin:T", title="Time (UTC)"),
+                alt.Tooltip("line_text:N", title="Line"),
+                alt.Tooltip(f"{label_col}:N", title="Stop"),
+                alt.Tooltip(f"{y_metric}:Q", title=metric_human_name(y_metric), format=".3f"),
+                alt.Tooltip("n_trips:Q", title="#Trips"),
+            ],
+        )
+        .properties(height=280)
+        .interactive()
+    )
+    st.altair_chart(timeseries, use_container_width=True)
+else:
+    st.info("Not enough data for time series.")
+
+# =============================================================================
+# Heatmap — hour × day (average delay)
+# =============================================================================
+st.subheader("Hour × Day heatmap (avg delay)")
+if not view.empty and "delay_avg_min" in view.columns:
+    dow_map = {0: "Mon", 1: "Tue", 2: "Wed", 3: "Thu", 4: "Fri", 5: "Sat", 6: "Sun"}
+    heat = (
+        view.assign(dow_name=view["dow"].map(dow_map))
+            .groupby(["dow", "dow_name", "hour"], as_index=False)["delay_avg_min"].mean()
+    )
+    heat_chart = (
+        alt.Chart(heat)
+        .mark_rect()
+        .encode(
+            x=alt.X("hour:O", title="Hour"),
+            y=alt.Y("dow_name:O", sort=["Mon","Tue","Wed","Thu","Fri","Sat","Sun"], title="Day"),
+            color=alt.Color("delay_avg_min:Q", title="Avg delay (min)"),
+            tooltip=[
+                alt.Tooltip("dow_name:O", title="Day"),
+                alt.Tooltip("hour:O", title="Hour"),
+                alt.Tooltip("delay_avg_min:Q", title="Avg delay (min)", format=".2f"),
+            ],
+        )
+        .properties(height=240)
+    )
+    st.altair_chart(heat_chart, use_container_width=True)
+else:
+    st.info("Not enough data for heatmap.")
+
+# =============================================================================
+# Details table + download
+# =============================================================================
+st.subheader("Details")
+if not view.empty:
+    st.dataframe(view.sort_values(["sched_bin", "line_text", "stop_key"]).reset_index(drop=True))
+    csv = view.to_csv(index=False).encode("utf-8")
+    st.download_button("Download filtered (CSV)", data=csv,
+                       file_name="by_stop_line_filtered.csv", mime="text/csv")
+else:
+    st.info("No rows for the current filters.")

--- a/src/11_build_features_by_stop_line.py
+++ b/src/11_build_features_by_stop_line.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#  src/11_build_features_by_stop_line.py
+"""
+11_build_features_by_stop_line.py — 10-minute aggregation by (line_text × stop_code)
+
+Overview
+--------
+Aggregates the canonical event-level table `features_events` over 10-minute bins
+(`sched_bin`) and writes the result to `features_by_stop_line` + Parquet.
+
+Why this table?
+---------------
+- Provides a compact, dashboard-friendly view per (line × stop × time bin).
+- Adds a stable `stop_key` = "{line_text}·{stop_code}" for filtering/joins.
+- Surfaces potential COALESCE bias at aggregate level via `share_coalesce`.
+
+Key metrics
+-----------
+- n_trips            : number of events in the bin
+- delay_avg_min      : average delay (minutes)
+- delay_p50_min      : median delay (minutes)        → MEDIAN(delay_min)
+- delay_p90_min      : 90th percentile delay (min)   → QUANTILE(delay_min, 0.9)
+- share_late_ge2     : share of events with delay ≥ 2 min
+- share_coalesce     : share of events where depart_* was substituted by arrival_*
+
+Weather aggregates (means/max) are included for quick EDA.
+
+CLI
+---
+--db         : optional DuckDB path (else from common.py)
+--log-level  : DEBUG | INFO | WARNING | ERROR  (default: INFO)
+
+Outputs
+-------
+- DuckDB table:  features_by_stop_line
+- Parquet file:  data/gold/features_by_stop_line.parquet
+
+Usage
+-----
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import duckdb
+
+from common import init_db, get_db
+from utils_logging import setup_logging
+
+PARQUET_OUT = Path("data/gold/features_by_stop_line.parquet")
+
+
+def ensure_parent_dir(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def table_exists(con: duckdb.DuckDBPyConnection, schema: str, name: str) -> bool:
+    return con.execute(
+        """
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = ? AND table_name = ?
+        LIMIT 1
+        """,
+        [schema, name],
+    ).fetchone() is not None
+
+
+def build_features_by_stop_line(con: duckdb.DuckDBPyConnection, log: logging.Logger) -> None:
+    """
+    Build the aggregated table from `features_events`:
+      - grouping keys: line_text, stop_code, stop_key, sched_bin
+      - metrics: n_trips, delays (avg/median/p90/share ≥2min), share_coalesce
+      - weather: mean/max summaries
+    """
+    if not table_exists(con, "main", "features_events"):
+        raise RuntimeError("features_events not found. Run 10_build first.")
+
+    # Build inside DuckDB (CTAS). We keep 10-minute bins as-is (no downsampling).
+    con.execute(
+        """
+        DROP TABLE IF EXISTS features_by_stop_line;
+
+        CREATE TABLE features_by_stop_line AS
+        WITH base AS (
+          SELECT
+            line_text,
+            stop_code,
+            COALESCE(stop_name, CAST(stop_code AS VARCHAR)) AS stop_name,
+            sched_bin,
+            delay_min,
+            any_coalesce_from_arrival,
+            -- weather at sched_bin
+            temp_c, rain_mm, wind_ms, gust_ms, wind_dir_deg,
+            humidity, pressure_hpa, global_rad_wm2, sunshine_min, dewpoint_c
+          FROM features_events
+          WHERE sched_bin IS NOT NULL
+        ),
+        aggr AS (
+          SELECT
+            line_text,
+            stop_code,
+            -- stop_key for dashboard filters and joins
+            line_text || '·' || CAST(stop_code AS VARCHAR) AS stop_key,
+            MAX(stop_name) AS stop_name,
+            sched_bin,
+
+            CAST(COUNT(*) AS BIGINT)                 AS n_trips,
+            CAST(AVG(delay_min) AS DOUBLE)           AS delay_avg_min,
+            MEDIAN(delay_min)                        AS delay_p50_min,
+            QUANTILE(delay_min, 0.9)                 AS delay_p90_min,
+
+            AVG(CAST(delay_min >= 2 AS DOUBLE))      AS share_late_ge2,
+            AVG(CAST(any_coalesce_from_arrival AS DOUBLE)) AS share_coalesce,
+
+            -- Weather summaries
+            AVG(temp_c)           AS temp_c_mean,
+            AVG(rain_mm)          AS rain_mm_mean,
+            MAX(rain_mm)          AS rain_mm_max,
+            AVG(wind_ms)          AS wind_ms_mean,
+            AVG(gust_ms)          AS gust_ms_mean,
+            AVG(wind_dir_deg)     AS wind_dir_deg_mean,
+            AVG(humidity)         AS humidity_mean,
+            AVG(pressure_hpa)     AS pressure_hpa_mean,
+            AVG(global_rad_wm2)   AS global_rad_wm2_mean,
+            AVG(sunshine_min)     AS sunshine_min_mean,
+            AVG(dewpoint_c)       AS dewpoint_c_mean
+
+          FROM base
+          GROUP BY 1,2,3,5
+        )
+        SELECT * FROM aggr
+        ORDER BY sched_bin DESC, line_text, stop_name;
+        """
+    )
+
+    # Small QC logging
+    qc = con.execute(
+        """
+        SELECT
+          COUNT(*)                                        AS rows_bins,
+          COUNT(DISTINCT sched_bin)                       AS unique_bins,
+          COUNT(DISTINCT line_text || '·' || CAST(stop_code AS VARCHAR)) AS unique_stop_keys
+        FROM features_by_stop_line
+        """
+    ).fetchone()
+    log.info("QC | bins=%s unique_bins=%s unique_stop_keys=%s", *qc)
+
+
+def export_parquet(con: duckdb.DuckDBPyConnection, out_path: Path, log: logging.Logger) -> None:
+    ensure_parent_dir(out_path)
+    con.execute(
+        f"""
+        COPY (SELECT * FROM features_by_stop_line)
+        TO '{out_path.as_posix()}'
+        (FORMAT 'parquet', COMPRESSION 'ZSTD');
+        """
+    )
+    n = con.execute("SELECT COUNT(*) FROM features_by_stop_line").fetchone()[0]
+    log.info("Parquet → %s (rows=%s)", out_path, f"{n:,}")
+
+
+def main(db: str | None, log_level: str = "INFO") -> None:
+    log = setup_logging("build_features_by_stop_line", log_level)
+    init_db(db)
+    con = get_db(db)
+
+    build_features_by_stop_line(con, log)
+    export_parquet(con, PARQUET_OUT, log)
+    log.info("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build features_by_stop_line (10-min aggregation).")
+    parser.add_argument("--db", default=None, help="DuckDB path (None → default from common.py)")
+    parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    args = parser.parse_args()
+
+    main(args.db, args.log_level)


### PR DESCRIPTION
- Adds ETL step `src/11_build_features_by_stop_line.py` (from features_events) to compute stop×line×10-min aggregates: 

> `n_trips`, `delay_avg_min`, `delay_p50_min`, `delay_p90_min`, `share_late_ge2`, `share_coalesce`, plus weather means/max

- Writes DuckDB table features_by_stop_line and Parquet `data/gold/features_by_stop_line.parquet`.
- Introduces `app/streamlit_by_stop_line.py` to explore metrics (filters by `stop_key`, date range, metric; timeseries + heatmap; CSV download).